### PR TITLE
allow dev_*.py modules to be located in testlib subdirs

### DIFF
--- a/README
+++ b/README
@@ -28,3 +28,4 @@ TAF package consists of two folders: ./taf-repo and ./testcases-repo. taf-repo f
 ## License:
 Apache 2.0. See LICENSE for more details.
 
+


### PR DESCRIPTION
recursively search for dev_*.py modules under testlib

Change-Id: If057f80fc3d8ce420c7974255ded9104eebb5852
Signed-off-by: Ross Brattain <ross.b.brattain@intel.com>