### PR TITLE
allow dev_*.py modules to be located in testlib subdirs

### DIFF
--- a/taf/testlib/common3.py
+++ b/taf/testlib/common3.py
@@ -41,6 +41,7 @@ VERSION = "3.0"
 # Accessible from other modules list of loaded classes from dev_ files.
 custom_classes = {}
 
+
 # Add soft exit with environment sanitizing before exit.
 def softexit(message, env=None):
     """
@@ -53,6 +54,8 @@ def softexit(message, env=None):
     if env is not None:
         env.sanitize()
     pytest.exit(message)
+
+
 pytest.softexit = softexit
 
 
@@ -209,8 +212,16 @@ class Environment(dict):
 
     def _find_dev_modules(self):
         # extract this so we can override in unittests
-        return [os.path.splitext(_m)[0] for _m in os.listdir(os.path.dirname(__file__))
-                if _m.startswith("dev_") and _m.endswith(".py")]
+        devices = []
+        testlib_path = os.path.dirname(__file__)
+        for root, dirname, filenames in os.walk(testlib_path):
+            for m in filenames:
+                if m.startswith("dev_") and m.endswith(".py"):
+                    rel_path = os.path.relpath(os.path.join(root, m), testlib_path)
+                    # create module name relative to testlib
+                    # foo/dev_bar.py -> foo.dev_bar
+                    devices.append(os.path.splitext(rel_path)[0].replace(os.sep, '.'))
+        return devices
 
     def _get_conf(self, file_name=None):
         """


### PR DESCRIPTION
recursively search for dev_*.py modules under testlib

Change-Id: If057f80fc3d8ce420c7974255ded9104eebb5852
Signed-off-by: Ross Brattain <ross.b.brattain@intel.com>