### PR TITLE
Rework attempt to simplify collectd.conf change.

### DIFF
--- a/taf/testlib/linux/ipmitool.py
+++ b/taf/testlib/linux/ipmitool.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-@copyright Copyright (c) 2015 - 2016, Intel Corporation.
+@copyright Copyright (c) 2015 - 2017, Intel Corporation.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/taf/testlib/linux/ipmitool.py
+++ b/taf/testlib/linux/ipmitool.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-@copyright Copyright (c) 2015 - 2017, Intel Corporation.
+@copyright Copyright (c) 2015 - 2016, Intel Corporation.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/taf/testlib/linux_host_bash.py
+++ b/taf/testlib/linux_host_bash.py
@@ -1,5 +1,5 @@
 """
-@copyright Copyright (c) 2015 - 2016, Intel Corporation.
+@copyright Copyright (c) 2015 - 2017, Intel Corporation.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ class LinuxHostBash(LinuxHostInterface):
         self.iperf = iperf.Iperf(self.cli_send_command)
         self.testpmd = testpmd.TestPmd(self.host)
         # Collectd tool
-        self.collectd = collectd.Collectd(self.cli_send_command, self.cli_set,
+        self.collectd = collectd.Collectd(self.cli_send_command,
                                           self.host.config.get('collectd_conf_path'))
         # Hugepages
         self.hugepages = hugepages.HugePages(self.cli_send_command)

--- a/taf/testlib/ui_onpss_shell/ui_onpss_shell.py
+++ b/taf/testlib/ui_onpss_shell/ui_onpss_shell.py
@@ -1,5 +1,5 @@
 """
-@copyright Copyright (c) 2015 - 2016, Intel Corporation.
+@copyright Copyright (c) 2015 - 2017, Intel Corporation.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -124,7 +124,7 @@ class UiOnpssShell(UiHelperMixin, UiInterface):
         self.maa = maa.MatchActionAcceleration(self.cli_send_command)
         self.stresstool = stresstool.StressTool(self.cli_send_command)
         # Collectd tool
-        self.collectd = collectd.Collectd(self.cli_send_command, self.cli_set,
+        self.collectd = collectd.Collectd(self.cli_send_command,
                                           self.switch.config.get('collectd_conf_path'))
         # Hugepages
         self.hugepages = hugepages.HugePages(self.cli_send_command)

--- a/unittests/test_collectd.py
+++ b/unittests/test_collectd.py
@@ -1,5 +1,5 @@
 """
-@copyright Copyright (c) 2016, Intel Corporation.
+@copyright Copyright (c) 2016-2017, Intel Corporation.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,79 +13,41 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-@file test_collectd.py
+@file  test_collectd.py
 
-@summary Collectd library unittests
+@summary  Collectd library unittests
 """
-import copy
-
 import pytest
 
 from testlib.linux import collectd
-from unittest.mock import (patch, MagicMock)
+from unittest.mock import MagicMock
+from testlib.custom_exceptions import CustomException
 
 
-class TestCollectd():
+class TestCollectd(object):
     @pytest.fixture(autouse=True)
-    def setup_tests(self, request):
-        self.fake_action = "fake_action"
-        self.fake_plugin = "fake_plugin"
+    def setup_tests(self):
         self.collectd_conf = "/test/collectd.conf"
         self.cli_send_mock = MagicMock()
         self.cli_set_mock = MagicMock()
 
-    def test_new_action(self, monkeypatch):
-        fake_actions = copy.deepcopy(collectd.ACTIONS)
-        fake_actions.update({self.fake_action: {}})
-        monkeypatch.setattr(collectd, "ACTIONS", fake_actions)
-        self.collectd_instance = collectd.Collectd(self.cli_send_mock, self.cli_set_mock, self.collectd_conf)
-        fake_action_attr = getattr(self.collectd_instance, self.fake_action, None)
-        assert fake_action_attr
-        assert all([getattr(fake_action_attr, plugin, None) for plugin in collectd.PLUGINS])
-
-    def test_new_plugin(self, monkeypatch):
-        fake_plugins = copy.deepcopy(collectd.PLUGINS)
-        monkeypatch.setattr(collectd, "PLUGINS", tuple(list(fake_plugins) + [self.fake_plugin]))
-        collectd.PLUGINS = tuple(list(collectd.PLUGINS) + [self.fake_plugin])
-        self.collectd_instance = collectd.Collectd(self.cli_send_mock, self.cli_set_mock, self.collectd_conf)
-        action_attr = [getattr(self.collectd_instance, action, None) for action in collectd.ACTIONS]
-        assert all(action_attr)
-        for action in action_attr:
-            assert getattr(action, self.fake_plugin, None)
-
     def test_collectd_start(self):
-        self.collectd_instance = collectd.Collectd(self.cli_send_mock, self.cli_set_mock, self.collectd_conf)
+        self.collectd_instance = collectd.Collectd(self.cli_send_mock, self.collectd_conf)
         self.collectd_instance.start()
         assert self.cli_send_mock.call_args[0][0] == 'systemctl start collectd.service'
 
     def test_collectd_stop(self):
-        self.collectd_instance = collectd.Collectd(self.cli_send_mock, self.cli_set_mock, self.collectd_conf)
+        self.collectd_instance = collectd.Collectd(self.cli_send_mock, self.collectd_conf)
         self.collectd_instance.stop()
         assert self.cli_send_mock.call_args[0][0] == 'systemctl stop collectd.service'
 
     def test_collectd_restart(self):
-        self.collectd_instance = collectd.Collectd(self.cli_send_mock, self.cli_set_mock, self.collectd_conf)
+        self.collectd_instance = collectd.Collectd(self.cli_send_mock, self.collectd_conf)
         self.collectd_instance.restart()
         assert self.cli_send_mock.call_args[0][0] == 'systemctl restart collectd.service'
 
-
-class TestCollectdConfCommandGenerator():
-    @pytest.fixture(autouse=True)
-    def setup_test(self):
-        self.cli_set_mock = MagicMock()
-        self.command_generator = collectd.command_generator
-        self.collectd_conf = '/test.conf/'
-
-    def test_run_disable_plugins(self):
-        action = 'disable'
-        collectd_conf_command_generator = collectd.CollectdConfCommandGenerator(action, self.command_generator,
-                                                                                self.collectd_conf)
-        self.collectd_conf_manager = collectd.CollectdPluginsManager(action, collectd_conf_command_generator,
-                                                                     self.cli_set_mock)
-        for plugin in collectd.PLUGINS:
-            getattr(self.collectd_conf_manager, plugin, None)()
-            expected = []
-            for cmd in collectd.ACTIONS[action]['cmd']:
-                expected.append([cmd.format(plugin=plugin, collectd_conf=self.collectd_conf)])
-
-            assert self.cli_set_mock.call_args[0][0] == expected
+    def test_collect_no_plugins_config(self):
+        self.collectd_instance = collectd.Collectd(self.cli_send_mock, self.collectd_conf)
+        self.collectd_instance.plugins_config = {}
+        with pytest.raises(CustomException, 'CustomException not raised in case of empty plugins config.'):
+            self.collectd_instance.update_config_file()


### PR DESCRIPTION
Added update_config_file() and few servicing functions.
As result, there are runtime accessible sections of collectd.conf
as lhost.ui.collectd.<section_data> structures; and a single method
recreating collectd.conf file based on that data.

All existing methods were kept for compatibility with many existing
test cases that are using those complex calls.

Updated code to use dict instead of list of tuples.
For consistency, added dependent files:
  - ipmitool.py
  - linux_host_bash.py

Resolved merge conflicts. Updated copyright dates.

Change-Id: I3956764c47b86b18416ec1554e1d268692b06aee
Signed-off-by: Voznyy, OrestX <orestx.voznyy@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/taf3/taf/11)
<!-- Reviewable:end -->
