### PR TITLE
Add call to super().__init__() where appropriate

### DIFF
--- a/taf/testlib/afscross.py
+++ b/taf/testlib/afscross.py
@@ -44,7 +44,7 @@ class AFS(GenericXConnectMixin):
         @type  env:  Environment
         """
         self.class_logger.debug("Create AFS object.")
-        self.opts = opts
+        super().__init__(config, opts)
 
         # Correcting AFS port map
         if "mapcorrector" in config:

--- a/taf/testlib/dev_basecross.py
+++ b/taf/testlib/dev_basecross.py
@@ -87,9 +87,7 @@ class ZeroCross(GenericXConnectMixin):
         """
         @brief  Initialize ZeroCross class
         """
-        self.id = config['id']
-        self.type = config['instance_type']
-        self.opts = opts
+        super().__init__(config, opts)
         self.autoconnect = True
 
     def xconnect(self, connection=None):

--- a/taf/testlib/dev_onsswcross.py
+++ b/taf/testlib/dev_onsswcross.py
@@ -48,12 +48,9 @@ class ONSSwitchCross(dev_basecross.GenericXConnectMixin):
         @param  opts:  py.test config.option object which contains all py.test cli options.
         @type  opts:  OptionParser
         """
+        super().__init__(config, opts)
         self.class_logger.info("Init ONS Switch Cross object.")
-        self.id = config['id']
-        self.type = config['instance_type']
         self.name = config['name'] if "name" in config else "noname"
-        self.config = config
-        self.opts = opts
         # Connections info:
         self.connections = []
         # Do xconnect on create?

--- a/taf/testlib/dev_ovscontroller.py
+++ b/taf/testlib/dev_ovscontroller.py
@@ -50,12 +50,13 @@ class OvsControllerGeneralMixin(entry_template.GenericEntry):
     """
     class_logger = loggers.ClassLogger()
 
-    def __init__(self, config):
+    def __init__(self, config, opts):
         """
         @brief  Initialize OvsControllerGeneralMixin class
         @param  config:  Configuration information.
         @type  config:  dict
         """
+        super().__init__(config, opts)
         self.val = config['related_id'][0]
         self.sw_type = config['related_conf'][self.val]['instance_type']
         if 'ip_host' in list(config.keys()):
@@ -460,10 +461,9 @@ class NoxControllerLocal(OvsControllerGeneralMixin):
         @param  opts:  py.test config.option object which contains all py.test cli options.
         @type  opts:  OptionParser
         """
-        super(NoxControllerLocal, self).__init__(config)
+        super(NoxControllerLocal, self).__init__(config, opts)
         self.popen = None
         self.pid = None
-        self.opts = opts
         self.cmdproxy = JsonCommand(self.json_ipaddr, self.port)
         self.waiton_err_message = "OVS controller is started but does not respond."
 
@@ -600,7 +600,7 @@ class FloodlightControllerLocal(OvsControllerGeneralMixin):
         @param  opts:  py.test config.option object which contains all py.test cli options.
         @type  opts:  OptionParser
         """
-        super(FloodlightControllerLocal, self).__init__(config)
+        super(FloodlightControllerLocal, self).__init__(config, opts)
         self.popen = None
         self.pid = None
         self.opts = opts
@@ -744,7 +744,7 @@ class OFtestControllerLocal(OvsControllerGeneralMixin):
         @param  opts:  py.test config.option object which contains all py.test cli options.
         @type  opts:  OptionParser
         """
-        super(OFtestControllerLocal, self).__init__(config)
+        super(OFtestControllerLocal, self).__init__(config, opts)
         self.popen = None
         self.pid = None
         self.opts = opts
@@ -874,7 +874,7 @@ class OvsControllerRemote(OvsControllerGeneralMixin):
         @param  opts:  py.test config.option object which contains all py.test cli options.
         @type  opts:  OptionParser
         """
-        super(OvsControllerRemote, self).__init__(config)
+        super(OvsControllerRemote, self).__init__(config, opts)
         self.popen = None
         self.pid = None
         self.opts = opts

--- a/taf/testlib/dev_staticcross_ons.py
+++ b/taf/testlib/dev_staticcross_ons.py
@@ -39,9 +39,7 @@ class StaticCrossONS(dev_basecross.GenericXConnectMixin):
         @param  opts:  py.test config.option object which contains all py.test cli options.
         @type  opts:  OptionParser
         """
-        self.id = config['id']
-        self.type = config['instance_type']
-        self.opts = opts
+        super().__init__(config, opts)
         self.autoconnect = config['autoconnect'] if "autoconnect" in config else True
 
         # Store configuration of related devices

--- a/taf/testlib/dev_vethcross.py
+++ b/taf/testlib/dev_vethcross.py
@@ -44,10 +44,8 @@ class VethCross(GenericXConnectMixin):
         @param  opts:  py.test config.option object which contains all py.test cli options.
         @type  opts:  OptionParser
         """
+        super().__init__(config, opts)
         self.class_logger.info("VethCross is selected.")
-        self.id = config['id']
-        self.type = config['instance_type']
-        self.opts = opts
         # Connections info:
         self.connections = []
         # Do xconnect on create?

--- a/taf/testlib/dev_vlabcross.py
+++ b/taf/testlib/dev_vlabcross.py
@@ -50,12 +50,10 @@ class VlabEnv(dev_basecross.GenericXConnectMixin):
         @type  opts:  OptionParser
         @raise  CrossException:  error in vlab path
         """
-        self.id = config['id']
-        self.type = config['instance_type']
+        super().__init__(config, opts)
         self.ipaddr = config['ip_host']
         self.port = config['ip_port'] if "ip_port" in config else "8050"
         self.ifaces = config['ports']
-        self.opts = opts
         # Do xconnect on create?
         self.autoconnect = config['autoconnect'] if "autoconnect" in config else True
 


### PR DESCRIPTION
Uppon receiving review comments about missing call to super __init__() I scanned the taf for W0231 warning (super-init-not-called). Pylint has showed this warning at 12 places and I tried to fixed that where I thought it was appropriate.
Have a look if it is worth fixing it.
It is not tested, though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/taf3/taf/21)
<!-- Reviewable:end -->
