### PR TITLE
Dockerfile: update Trex version, remove /etc/environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ MAINTAINER intel.com
 
 # define proxy environment variables to build image
 # if environment requires
-#ENV http_proxy 'http://<proxy server>:<port>'
-#ENV https_proxy 'http://<proxy server>:<port>'
-#ENV ftp_proxy 'http://<proxy server>:<port>'
-#ENV socks_proxy 'socks://<proxy server>:<port>'
-#ENV no_proxy 'localhost,127.0.0.1,.<example.com>'
+#ENV http_proxy='http://<proxy server>:<port>'
+#ENV https_proxy='http://<proxy server>:<port>'
+#ENV ftp_proxy='http://<proxy server>:<port>'
+#ENV socks_proxy='socks://<proxy server>:<port>'
+#ENV no_proxy='localhost,127.0.0.1,.<example.com>'
 
 # create apt proxy
 #RUN echo 'Acquire::http::Proxy "<proxy server>";' >>/etc/apt/apt.conf.d/20proxy
@@ -56,6 +56,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get autoremove \
     && apt-get clean
 
+# Set the locale to C.UTF-8 for Python 3
+ENV LANG=C.UTF-8
 
 # need to specify path to Ixia client library and
 # copy ixia files where X.XX is Ixia version
@@ -90,9 +92,6 @@ mock \n\
 ' > /root/requirements.txt && pip install --upgrade -r /root/requirements.txt && rm /root/requirements.txt && rm -rf /root/.cache/pip
 
 
-# always need /etc/environment for IXIA and TCL vars
-COPY docker_environment_variables /etc/environment
-
 ARG TAF_ROOT=/root/taf
 # copy TAF repo to docker image
 COPY /  $TAF_ROOT/
@@ -107,7 +106,7 @@ RUN pip install -r $TAF_ROOT/requirements.txt
 
 
 # copy TRex client API library
-ARG TREX_VERSION=v2.00
+ARG TREX_VERSION=v2.20
 ARG TREX_TMP_PATH=/tmp/trex
 ARG TREX_WEB_URL=http://trex-tgn.cisco.com/trex/release
 ENV TREX_CLIENT_LIB=/opt/trex_client/stl


### PR DESCRIPTION
We need Trex v2.20 to workaround Python 3.5 pyzmq import error

Also /etc/enviroment doens't work with Docker so we need
to set all vars using ENV A="B"

Change-Id: I5ffc2043d6e0c6f37f579bea5a37c33d85a7ed3f
Signed-off-by: Ross Brattain <ross.b.brattain@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/taf3/taf/28)
<!-- Reviewable:end -->
