### PR TITLE
Fixed issue with test runs being aborted prematurely due to ssh error

### DIFF
--- a/taf/testlib/dev_linux_host.py
+++ b/taf/testlib/dev_linux_host.py
@@ -751,8 +751,6 @@ class GenericLinuxHost(entry_template.GenericEntry):
         @param retry_count:  Number of retries to start(restart) linux host
         @type  retry_count:  int
         @return None or raise an exception.
-        @note  Also self.opts.fail_ctrl attribute affects logic of this method.
-               fail_ctrl is set in py.test command line options (read py.test --help for more information).
         """
         # If fail_ctrl != "restart", restart retries won't be performed
         # as restart is not implemented for lhosts, retries makes no sense.
@@ -779,10 +777,7 @@ class GenericLinuxHost(entry_template.GenericEntry):
                 self.name, self.ipaddr, "".join(traceback_message))
             sys.stderr.write(message)
             sys.stderr.flush()
-            if self.opts.fail_ctrl != "ignore":
-                pytest.exit(message)
-            else:
-                pytest.fail(message)
+            pytest.fail(message)
 
     def waiton(self, timeout=DEFAULT_SERVER_WAIT_ON_TIMEOUT):
         """


### PR DESCRIPTION
fail_ctrl parameter (stop, restart, ignore) controls what TAF does when TAF cannot ssh to device. For linux machines, restart (default) is not available. In addition, we don't want it to stop test runs if ssh is unavailable.

Signed-off-by: Jennifer Li <jennifer.li@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/taf3/taf/30)
<!-- Reviewable:end -->
