### PR TITLE
Fixed pytest.raises() call in unittests/test_collectd.py.

### DIFF
--- a/unittests/test_collectd.py
+++ b/unittests/test_collectd.py
@@ -49,5 +49,5 @@ class TestCollectd(object):
     def test_collect_no_plugins_config(self):
         self.collectd_instance = collectd.Collectd(self.cli_send_mock, self.collectd_conf)
         self.collectd_instance.plugins_config = {}
-        with pytest.raises(CustomException, 'CustomException not raised in case of empty plugins config.'):
+        with pytest.raises(CustomException, message='CustomException not raised in case of empty plugins config.'):
             self.collectd_instance.update_config_file()


### PR DESCRIPTION
Fixed pytest.raises() call in unittests/test_collectd.py.

Errors log:
E             File "<string>", line 1
E               CustomException not raised in case of empty plugins config.
E                                        ^
E           SyntaxError: CustomException not raised in case of empty plugins config.
E                                     ^
E           (code was compiled probably from here: <0-codegen /usr/local/lib/python3.4/dist-packages/_pytest/python.py:1309>)

Signed-off-by: Orest Voznyy <orestx.voznyy@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/taf3/taf/31)
<!-- Reviewable:end -->
