### PR TITLE
External network creation changes

### DIFF
--- a/taf/plugins/pytest_tempest.py
+++ b/taf/plugins/pytest_tempest.py
@@ -48,7 +48,8 @@ def pytest_addoption(parser):
         },
         '--reuse_venv': {
             'action': 'store',
-            'default': True,
+            'default': 'True',
+            'choices': ['True', 'False'],
             'help': "Reuse(=True) or Delete(=False) existing public networks/routers\
             , '%default' by default.",
         },


### PR DESCRIPTION
- Removed external router creation
- fixed external networks detection - removed router lookup
- If external network present: deleting floating IPs, unbinding from any router and deleting that network
- if more than one external network -> deleting all
- cleaned up passed clients -> external should always be handled by admin project

Signed-off-by: Maciej Skrocki <maciej.skrocki@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/taf3/taf/33)
<!-- Reviewable:end -->
