### PR TITLE
Changed collectd.conf location definition

### DIFF
--- a/taf/testlib/linux/service_lib.py
+++ b/taf/testlib/linux/service_lib.py
@@ -136,6 +136,7 @@ COMMANDS = {
     "is_active",
     "list",
     "daemon_reload",
+    "cat"
 }
 
 

--- a/taf/testlib/linux_host_bash.py
+++ b/taf/testlib/linux_host_bash.py
@@ -102,8 +102,7 @@ class LinuxHostBash(LinuxHostInterface):
         self.iperf = iperf.Iperf(self.cli_send_command)
         self.testpmd = testpmd.TestPmd(self.host)
         # Collectd tool
-        self.collectd = collectd.Collectd(self.cli_send_command,
-                                          self.host.config.get('collectd_conf_path'))
+        self.collectd = collectd.Collectd(self.cli_send_command)
         # Hugepages
         self.hugepages = hugepages.HugePages(self.cli_send_command)
 
@@ -369,7 +368,8 @@ class LinuxHostBash(LinuxHostInterface):
             results = [r[0].splitlines() for r in results]
         return results
 
-    def process_table_data(self, data, table_keys_mapping):
+    @staticmethod
+    def process_table_data(data, table_keys_mapping):
         """Returns dictionary of items, given a table of elements.
 
         Args:

--- a/unittests/test_collectd.py
+++ b/unittests/test_collectd.py
@@ -23,33 +23,25 @@ import pytest
 
 from testlib.linux import collectd
 from unittest.mock import MagicMock
-from testlib.custom_exceptions import CustomException
 
 
 class TestCollectd(object):
     @pytest.fixture(autouse=True)
     def setup_tests(self):
-        self.collectd_conf = "/test/collectd.conf"
         self.cli_send_mock = MagicMock()
         self.cli_set_mock = MagicMock()
 
     def test_collectd_start(self):
-        self.collectd_instance = collectd.Collectd(self.cli_send_mock, self.collectd_conf)
+        self.collectd_instance = collectd.Collectd(self.cli_send_mock)
         self.collectd_instance.start()
         assert self.cli_send_mock.call_args[0][0] == 'systemctl start collectd.service'
 
     def test_collectd_stop(self):
-        self.collectd_instance = collectd.Collectd(self.cli_send_mock, self.collectd_conf)
+        self.collectd_instance = collectd.Collectd(self.cli_send_mock)
         self.collectd_instance.stop()
         assert self.cli_send_mock.call_args[0][0] == 'systemctl stop collectd.service'
 
     def test_collectd_restart(self):
-        self.collectd_instance = collectd.Collectd(self.cli_send_mock, self.collectd_conf)
+        self.collectd_instance = collectd.Collectd(self.cli_send_mock)
         self.collectd_instance.restart()
         assert self.cli_send_mock.call_args[0][0] == 'systemctl restart collectd.service'
-
-    def test_collect_no_plugins_config(self):
-        self.collectd_instance = collectd.Collectd(self.cli_send_mock, self.collectd_conf)
-        self.collectd_instance.plugins_config = {}
-        with pytest.raises(CustomException, message='CustomException not raised in case of empty plugins config.'):
-            self.collectd_instance.update_config_file()


### PR DESCRIPTION
Collectd methods are based on systemctl calls.
Thus it is logical to retrieve collectd.conf file
location from collectd.service file of DUT.
It is defined using collectd option "-C <fname>".

Test run setup_file (JSON) key "collectd_conf_path"
gets obsoleted.

Added "cat" command to service_lib.py.

Updated collectd object definition in linux_host_bash.py.

Signed-off-by: Orest Voznyy <orestx.voznyy@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/taf3/taf/42)
<!-- Reviewable:end -->
