### PR TITLE
Reused testpmd params conversion in openvswitch.py

### DIFF
--- a/taf/testlib/linux/testpmd.py
+++ b/taf/testlib/linux/testpmd.py
@@ -61,6 +61,20 @@ STANDALONE_ARGS = {'huge_unlink': '--huge-unlink',
                    'no_shconf': '--no-shconf'}
 
 
+def reformat_dpdk_eal_options(**kwargs):
+    """Re-format DPDK EAL options from human-readable dict format to command-line parameters string.
+
+    """
+    assert all([par in ARGS_MAP or par in STANDALONE_ARGS for par in kwargs]), \
+        "Unsupported arguments are passed into current method. Supported are: \n {}\n{}".format(ARGS_MAP.keys(),
+                                                                                                STANDALONE_ARGS.keys())
+    inserts = ' '.join('{} {}'.format(ARGS_MAP[param], str(val))
+                       for param, val in kwargs.items() if param in ARGS_MAP)
+    inserts = inserts + ' ' + ' '.join(
+        [str(STANDALONE_ARGS[param]) for param, val in kwargs.items() if param in STANDALONE_ARGS and val])
+    return inserts
+
+
 class TestPmd(object):
     def __init__(self, host):
         """Initialize TestPmd class.
@@ -90,11 +104,7 @@ class TestPmd(object):
             None
 
         """
-        assert all([par in ARGS_MAP or par in STANDALONE_ARGS for par in kwargs]), \
-            "Unsupported arguments are passed into current method. Supported are: \n {}\n{}".format(ARGS_MAP.keys(), STANDALONE_ARGS.keys())
-        inserts = ' '.join('{} {}'.format(ARGS_MAP[param], str(val))
-                           for param, val in kwargs.items() if param in ARGS_MAP)
-        inserts = inserts + ' ' + ' '.join([str(STANDALONE_ARGS[param]) for param, val in kwargs.items() if param in STANDALONE_ARGS and val])
+        inserts = reformat_dpdk_eal_options(**kwargs)
 
         if interactive_shell:
             command = 'testpmd {} -- {} -i'.format(inserts, end_options)


### PR DESCRIPTION
Separated code converting DPDK EAL options from human readable format
to DPDK EAL internal format.

Added argument to openvswitch start call to indicate one of following
OVS service start modes:
  - OVS with DPDK (OVS must be pre-built with DPDK support)
  - vanilla OVS (DPDK support switched off, OVS pre-built with DPDK)

Mode is set via env var DPDK_OPTS in file /etc/default/openvswitch-switch.
No explicit openvswitch service file change occurs.

Signed-off-by: Orest Voznyy <orestx.voznyy@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/taf3/taf/43)
<!-- Reviewable:end -->
