### PR TITLE
Change pytest version requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytest>=2.9.2
+pytest==3.0.0
 pyasn1>=0.1.9
 pysnmp>=4.3.2
 jira>=1.0.3


### PR DESCRIPTION
- Changed pytest version requirements from "pytest>=2.9.2" to "pytest==3.0.0"
  Newer pytest versions give "ImportError: Error importing plugin 'plugins.pytest_skip_fileter': cannot import name 'cached_eval'" using taf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/taf3/taf/50)
<!-- Reviewable:end -->
