### PR TITLE
Change pytest-xdist version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ netaddr==0.7.18
 paramiko>=2.0.1
 cryptography==1.7.1
 py2chainmap>=0.1.0
-pytest-xdist>=1.11
+pytest-xdist==1.24.1
 PyYAML==3.11
 Pygments>=2.1.3
 pcapy>=0.11.1


### PR DESCRIPTION
  - Freeze pytest-xdist version to 1.24.1; Newer versions cause incompatibility issues with pytest 3.0.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/taf3/taf/51)
<!-- Reviewable:end -->
